### PR TITLE
Add simple Next.js certification tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # helloworld
-githubの使い方を学ぶためのサンプルリポジトリ
+
+Next.js を使った IT 資格管理アプリのサンプルです。
+
+## 開発の始め方
+
+```bash
+npm install
+npm run dev
+```
+
+ブラウザで `http://localhost:3000` にアクセスすると資格一覧が表示されます。
+
+## 機能
+- IPA や AWS、Azure などの資格をリスト形式で表示
+- チェックボックスで取得済み/未取得を切り替え可能

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cert-manager",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+const initialData = [
+  { id: 1, provider: 'IPA', title: '基本情報技術者', acquired: false },
+  { id: 2, provider: 'AWS', title: 'Solutions Architect Associate', acquired: true },
+  { id: 3, provider: 'Azure', title: 'AZ-900', acquired: false }
+];
+
+export default function Home() {
+  const [certs, setCerts] = useState(initialData);
+
+  const toggle = (id) => {
+    setCerts(certs.map(c => c.id === id ? { ...c, acquired: !c.acquired } : c));
+  };
+
+  return (
+    <div>
+      <h1>IT資格管理</h1>
+      <ul>
+        {certs.map(c => (
+          <li key={c.id}>
+            <label>
+              <input
+                type="checkbox"
+                checked={c.acquired}
+                onChange={() => toggle(c.id)}
+              />
+              {c.provider}: {c.title}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize minimal Next.js project
- show list of IT certifications with toggle for acquisition
- update README with setup instructions

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_6899d1d372fc8325ad8ec001d3c3e939